### PR TITLE
hotfix

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -102,7 +102,7 @@ app.use((req, res, next) => {
 
 app.use('/api', require('./api'));
 
-app.get('*', (req, res) => {
+app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, '../public/index.html'));
 });
 


### PR DESCRIPTION
Bug:
When deployed to heroku the app opens with a blank screen and the console shows the following error:
`Uncaught SyntaxError: Unexpected token '<'`

It seems like Heroku is receiving text/html when it expects javascript

Changes this PR:
Removed wildcard from get request for the base api so that when heroku requests a js file it does not receive html.